### PR TITLE
Executor returns only one error after halting

### DIFF
--- a/service/interpreter/primitive/interfaces/executor.vb
+++ b/service/interpreter/primitive/interfaces/executor.vb
@@ -68,7 +68,7 @@ Namespace primitive
         Function states_size() As UInt64
 
         Function halt() As Boolean
-        Function errors() As vector(Of error_type)
+        Function halt_error() As error_type
 
         Sub execute()
     End Interface

--- a/service/interpreter/primitive/interfaces/executor.vb
+++ b/service/interpreter/primitive/interfaces/executor.vb
@@ -4,40 +4,31 @@ Option Infer Off
 Option Strict On
 
 Imports System.Runtime.CompilerServices
-Imports System.Text
 Imports osi.root.connector
 Imports osi.root.constants
 Imports osi.root.formation
-Imports osi.service.math
 
 Namespace primitive
     Public NotInheritable Class executor_stop_error
         Inherits Exception
 
-        Public ReadOnly error_types() As executor.error_type
+        Public ReadOnly error_type As executor.error_type
 
-        Public Sub New(ByVal ParamArray error_types() As executor.error_type)
-            Me.error_types = error_types
-        End Sub
-
-        Public Shared Sub [throw](ByVal ParamArray error_types() As executor.error_type)
-            Throw New executor_stop_error(error_types)
+        Public Sub New(ByVal error_type As executor.error_type)
+            Me.error_type = error_type
         End Sub
 
         Public Shared Sub [throw](ByVal error_type As executor.error_type)
-            [throw]({error_type})
+            Throw New executor_stop_error(error_type)
         End Sub
 
         Public Shared Sub [throw](ByVal error_type As executor.error_type, ByVal ParamArray log_msg() As Object)
             raise_error(root.constants.error_type.user, log_msg)
-            [throw]({error_type})
+            [throw](error_type)
         End Sub
 
         Public Overrides Function ToString() As String
-            Return streams.of(error_types).
-                           collect(stream(Of executor.error_type).collectors.to_str(),
-                                   New StringBuilder("executor_stop_error: ")).
-                           ToString()
+            Return "executor_stop_error: " + error_type.ToString()
         End Function
     End Class
 

--- a/service/interpreter/primitive/simulator.vb
+++ b/service/interpreter/primitive/simulator.vb
@@ -14,9 +14,9 @@ Namespace primitive
     Public NotInheritable Class simulator
         Implements imitation
 
-        Private Shared ReadOnly bit_count_in_uint32 As Int32 = CInt(root.constants.bit_count_in_byte * sizeof_uint32)
+        Private Shared ReadOnly bit_count_in_uint32 As Int32 = CInt(bit_count_in_byte * sizeof_uint32)
 
-        Private ReadOnly _errors As New vector(Of executor.error_type)()
+        Private ReadOnly _error As New ref(Of executor.error_type)()
         Private ReadOnly _instructions As New vector(Of instruction)()
         Private ReadOnly _stack As New vector(Of ref(Of Byte()))()
         Private ReadOnly _states As New vector(Of executor.state)()
@@ -64,8 +64,9 @@ Namespace primitive
             _imaginary_number = v
         End Sub
 
-        Public Function errors() As vector(Of executor.error_type) Implements executor.errors
-            Return _errors
+        Public Function halt_error() As executor.error_type Implements executor.halt_error
+            assert(Not _error.empty())
+            Return _error.get()
         End Function
 
         Public Function halt() As Boolean Implements executor.halt
@@ -223,7 +224,7 @@ Namespace primitive
 
         Private Sub halt(ByVal ex As executor_stop_error)
             assert(Not ex Is Nothing)
-            _errors.emplace_back(ex.error_type)
+            _error.set(ex.error_type)
             _halt = True
         End Sub
 

--- a/service/interpreter/primitive/simulator.vb
+++ b/service/interpreter/primitive/simulator.vb
@@ -223,7 +223,7 @@ Namespace primitive
 
         Private Sub halt(ByVal ex As executor_stop_error)
             assert(Not ex Is Nothing)
-            _errors.emplace_back(ex.error_types)
+            _errors.emplace_back(ex.error_type)
             _halt = True
         End Sub
 

--- a/service/tests/compiler/b2style/b2style_test.vb
+++ b/service/tests/compiler/b2style/b2style_test.vb
@@ -785,11 +785,11 @@ Public NotInheritable Class b2style_test
                                   parse(_b2style_test_data.vector_destructor.as_text(), e))
         assertion.is_not_null(e)
         e.assert_execute_without_errors()
-        assertion.array_equal(assertion.catch_thrown(Of executor_stop_error) _
-                                                        (Sub()
-                                                             direct_cast(Of simulator)(e).access_heap(0)
-                                                         End Sub).error_types,
-                              {executor.error_type.heap_access_out_of_boundary})
+        assertion.equal(assertion.catch_thrown(Of executor_stop_error) _
+                                                  (Sub()
+                                                       direct_cast(Of simulator)(e).access_heap(0)
+                                                   End Sub).error_type,
+                        executor.error_type.heap_access_out_of_boundary)
     End Sub
 
     Private Sub New()

--- a/service/tests/compiler/executor.ext.vb
+++ b/service/tests/compiler/executor.ext.vb
@@ -4,6 +4,7 @@ Option Infer Off
 Option Strict On
 
 Imports System.Runtime.CompilerServices
+Imports osi.root.formation
 Imports osi.root.utt
 Imports osi.service.interpreter.primitive
 
@@ -13,6 +14,6 @@ Public Module _executor_ext
             Return False
         End If
         this.execute()
-        Return assertion.is_false(this.halt()) And assertions.of(this.errors()).empty()
+        Return assertion.is_false(this.halt(), lazier.of(AddressOf this.halt_error))
     End Function
 End Module

--- a/service/tests/compiler/logic/executor_case.vb
+++ b/service/tests/compiler/logic/executor_case.vb
@@ -46,8 +46,7 @@ Namespace logic
                 Return False
             End If
             e.execute()
-            assertion.is_false(e.halt())
-            assertion.is_true(e.errors().empty())
+            assertion.is_false(e.halt(), lazier.of(AddressOf e.halt_error))
             Try
                 check_result(not_null.[New](e))
             Catch ex As executor_stop_error

--- a/service/tests/compiler/logic/import_executor_tests.vb
+++ b/service/tests/compiler/logic/import_executor_tests.vb
@@ -129,11 +129,11 @@ Namespace logic
         Protected Overrides Sub check_result(ByVal e As not_null(Of simulator))
             MyBase.check_result(e)
             assertion.equal(io.output(), Convert.ToChar(99))
-            assertion.array_equal(assertion.catch_thrown(Of executor_stop_error) _
+            assertion.equal(assertion.catch_thrown(Of executor_stop_error) _
                                                         (Sub()
                                                              e.get().access_heap(0)
-                                                         End Sub).error_types,
-                                  {executor.error_type.heap_access_out_of_boundary})
+                                                         End Sub).error_type,
+                            executor.error_type.heap_access_out_of_boundary)
         End Sub
     End Class
 

--- a/service/tests/compiler/logic/importer_test.vb
+++ b/service/tests/compiler/logic/importer_test.vb
@@ -108,8 +108,7 @@ Namespace logic
                     Return False
                 End If
                 e.execute()
-                assertion.is_false(e.halt())
-                assertion.equal(e.errors().size(), uint32_0)
+                assertion.is_false(e.halt(), lazier.of(AddressOf e.halt_error))
                 For j As UInt32 = 0 To array_size(cases(CInt(i)).second) - uint32_1
                     Dim x() As Byte = Nothing
                     Try

--- a/service/tests/interpreter/primitive/executor_stop_error_test.vb
+++ b/service/tests/interpreter/primitive/executor_stop_error_test.vb
@@ -12,11 +12,8 @@ Namespace logic
     Public NotInheritable Class executor_stop_error_test
         <test>
         Private Shared Sub to_string()
-            assertions.of(New executor_stop_error(executor.error_type.instruction_ref_overflow,
-                                                  executor.error_type.interrupt_failure).
-                                                 ToString()).
-                       contains(executor.error_type.instruction_ref_overflow.ToString(),
-                                executor.error_type.interrupt_failure.ToString())
+            assertions.of(New executor_stop_error(executor.error_type.instruction_ref_overflow).ToString()).
+                       contains(executor.error_type.instruction_ref_overflow.ToString())
         End Sub
 
         Private Sub New()

--- a/service/tests/interpreter/primitive/loaded_method_test.vb
+++ b/service/tests/interpreter/primitive/loaded_method_test.vb
@@ -77,10 +77,10 @@ Namespace primitive
             l.load(str_bytes(strcat("osi.tests.service.interpreter.primitive.loaded_method_test, ",
                                     "osi.tests.service.interpreter",
                                     ":thrown_action")))
-            assertion.array_equal(assertion.catch_thrown(Of executor_stop_error)(Sub()
-                                                                                     l.execute(str_bytes("abc"))
-                                                                                 End Sub).error_types,
-                                  {executor.error_type.interrupt_failure})
+            assertion.equal(assertion.catch_thrown(Of executor_stop_error)(Sub()
+                                                                               l.execute(str_bytes("abc"))
+                                                                           End Sub).error_type,
+                            executor.error_type.interrupt_failure)
         End Sub
 
         Private Shared Sub unsatisfied_signature_1(ByVal i() As Byte)

--- a/service/tests/interpreter/primitive/simulator_stdio_test.vb
+++ b/service/tests/interpreter/primitive/simulator_stdio_test.vb
@@ -6,6 +6,7 @@ Option Strict On
 Imports System.IO
 Imports osi.root.constants
 Imports osi.root.connector
+Imports osi.root.formation
 Imports osi.root.utt
 Imports osi.service.interpreter.primitive
 Imports osi.service.resource
@@ -15,18 +16,15 @@ Namespace primitive
         Inherits [case]
 
         Private Shared Function output_case() As Boolean
-            Dim s As simulator = Nothing
-            Dim io As console_io = Nothing
-            io = New console_io()
-            s = New simulator(New interrupts(io))
+            Dim io As New console_io()
+            Dim s As New simulator(New interrupts(io))
             assertion.is_true(s.import(sim3.as_text()))
             Using out As TextWriter = New StringWriter(),
                   err As TextWriter = New StringWriter()
                 io.redirect_output(out)
                 io.redirect_error(err)
                 s.execute()
-                assertion.is_false(s.halt())
-                assertion.is_true(s.errors().empty())
+                assertion.is_false(s.halt(), lazier.of(AddressOf s.halt_error))
                 assertion.equal(Convert.ToString(out),
                              "hello world" + character.newline + "hello world" + character.newline)
                 assertion.equal(Convert.ToString(err),
@@ -47,8 +45,7 @@ Namespace primitive
                 io.redirect_output(out)
                 io.redirect_error(err)
                 s.execute()
-                assertion.is_false(s.halt())
-                assertion.is_true(s.errors().empty())
+                assertion.is_false(s.halt(), lazier.of(AddressOf s.halt_error))
                 assertion.equal(Convert.ToString(out), strcat(input, input))
                 assertion.equal(Convert.ToString(err), strcat(input, input))
             End Using
@@ -60,8 +57,7 @@ Namespace primitive
             Dim s As New simulator(New interrupts(+io))
             assertion.is_true(s.import(sim8.as_text()))
             s.execute()
-            assertion.is_false(s.halt())
-            assertion.is_true(s.errors().empty())
+            assertion.is_false(s.halt(), lazier.of(AddressOf s.halt_error))
             assertion.equal(io.output().Length(), 4)
             assertion.equal(Convert.ToInt32(io.output()(0)), 1)
             assertion.equal(Convert.ToInt32(io.output()(1)), 2)

--- a/service/tests/interpreter/primitive/simulator_test.vb
+++ b/service/tests/interpreter/primitive/simulator_test.vb
@@ -86,11 +86,11 @@ Namespace primitive
             End If
 
             assertion.equal(sim.access_as_uint32(data_ref.abs(0)), CUInt(100))
-            assertion.array_equal(assertion.catch_thrown(Of executor_stop_error) _
+            assertion.equal(assertion.catch_thrown(Of executor_stop_error) _
                                                         (Sub()
                                                              sim.access(data_ref.habs(1))
-                                                         End Sub).error_types,
-                                  {executor.error_type.heap_access_out_of_boundary})
+                                                         End Sub).error_type,
+                            executor.error_type.heap_access_out_of_boundary)
             Return True
         End Function
 

--- a/service/tests/interpreter/primitive/simulator_test.vb
+++ b/service/tests/interpreter/primitive/simulator_test.vb
@@ -28,8 +28,7 @@ Namespace primitive
             End If
             assertion.is_true(sim.import(s))
             sim.execute()
-            assertion.is_false(sim.halt())
-            assertion.is_true(sim.errors().empty())
+            assertion.is_false(sim.halt(), lazier.of(AddressOf sim.halt_error))
             Return True
         End Function
 

--- a/service/tests/interpreter/primitive/states_test.vb
+++ b/service/tests/interpreter/primitive/states_test.vb
@@ -26,9 +26,7 @@ Namespace primitive
                 assertion.is_true(s.import(sim6.as_text()))
                 s.execute()
                 assertion.is_true(s.halt())
-                If assertion.equal(s.errors().size(), uint32_1) Then
-                    assertion.equal(s.errors()(uint32_0), executor.error_type.stack_access_out_of_boundary)
-                End If
+                assertion.equal(s.halt_error(), executor.error_type.stack_access_out_of_boundary)
                 Return True
             End Function
         End Class


### PR DESCRIPTION
The support of multiple errors when halting has never been used and the concept is not reasonable.