### PR TITLE
Implement thread_static_argument_default and use it in disable_cycle_dependency_check

### DIFF
--- a/root/connector/connector.vbproj
+++ b/root/connector/connector.vbproj
@@ -119,6 +119,7 @@
     <Compile Include="functor\string_serializer\uri_serializer.vb" />
     <Compile Include="garbage_collector.vb" />
     <Compile Include="GlobalSuppressions.vb" />
+    <Compile Include="implementation_of\thread_static_argument_default.vb" />
     <Compile Include="managed_thread_pool.vb" />
     <Compile Include="mono.vb" />
     <Compile Include="ref\array_ref.vb" />

--- a/root/connector/implementation_of/thread_static_argument_default.vb
+++ b/root/connector/implementation_of/thread_static_argument_default.vb
@@ -1,0 +1,37 @@
+﻿
+Option Explicit On
+Option Infer Off
+Option Strict On
+
+Imports osi.root.delegates
+
+Public NotInheritable Class thread_static_argument_default(Of T, PROTECTOR)
+    Private ReadOnly d As T
+
+    Public Sub New(ByVal d As T)
+        Me.d = d
+    End Sub
+
+    Public Shared Operator Or(ByVal this As argument(Of T),
+                              ByVal that As thread_static_argument_default(Of T, PROTECTOR)) As T
+        assert(Not that Is Nothing)
+        If -this Then
+            Return +this
+        End If
+
+        Return thread_static_resolver(Of ref(Of T), PROTECTOR).resolve_or_default(ref.of(that.d)).get()
+    End Operator
+
+    Public Shared Function scoped_register(ByVal d As T) As IDisposable
+        Return thread_static_resolver(Of ref(Of T), PROTECTOR).scoped_register(ref.of(d))
+    End Function
+End Class
+
+Public NotInheritable Class thread_static_argument_default(Of PROTECTOR)
+    Public Shared Function [of](Of T)(ByVal v As T) As thread_static_argument_default(Of T, PROTECTOR)
+        Return New thread_static_argument_default(Of T, PROTECTOR)(v)
+    End Function
+
+    Private Sub New()
+    End Sub
+End Class

--- a/root/connector/implementation_of/thread_static_implementation_of.vb
+++ b/root/connector/implementation_of/thread_static_implementation_of.vb
@@ -49,11 +49,6 @@ Public NotInheritable Class thread_static_implementation_of(Of T)
             Return thread_static_resolver(Of Func(Of T), impl).resolve(r)
         End Function
 
-        Public Shared Shadows Operator +(ByVal this As impl) As impl
-            assert(object_compare([default], this) = 0 OrElse this Is Nothing)
-            Return [default]
-        End Operator
-
         Private Sub New()
         End Sub
     End Class

--- a/service/automata/syntax/matching.vb
+++ b/service/automata/syntax/matching.vb
@@ -13,6 +13,9 @@ Partial Public NotInheritable Class syntaxer
     Public MustInherit Class matching
         Implements IComparable, IComparable(Of matching)
 
+        Private Interface disable_cycle_dependency_check_protector
+        End Interface
+
         Private Shared disable_cycle_dependency_check As argument(Of Boolean)
 
         <ThreadStatic> Private Shared s As map(Of UInt32, UInt32)
@@ -22,6 +25,11 @@ Partial Public NotInheritable Class syntaxer
             assert(Not c Is Nothing)
             Me.c = c
         End Sub
+
+        Public Shared Function disable_cycle_dependency_check_in_thread() As IDisposable
+            Return thread_static_argument_default(Of Boolean, disable_cycle_dependency_check_protector).
+                       scoped_register(True)
+        End Function
 
         Public Structure result
             Public NotInheritable Class suc_t
@@ -119,7 +127,8 @@ Partial Public NotInheritable Class syntaxer
                                ByVal type As UInt32,
                                ByVal pos As UInt32,
                                ByVal f As Func(Of result)) As result
-            If disable_cycle_dependency_check Or False Then
+            If disable_cycle_dependency_check Or
+               thread_static_argument_default(Of disable_cycle_dependency_check_protector).of(False) Then
                 Return f()
             End If
             assert(Not f Is Nothing)

--- a/service/compiler/code_gen/code_gen_rule_wrapper.vb
+++ b/service/compiler/code_gen/code_gen_rule_wrapper.vb
@@ -120,7 +120,9 @@ Public Class code_gen_rule_wrapper(Of WRITER As New,
 
     Public Shared Function parse(ByVal input As String, ByVal o As WRITER) As Boolean
         Using thread_static_implementation_of(Of builder).scoped_register(New builder())
-            Return thread_static_implementation_of(Of builder).resolve().build(input, o)
+            Using syntaxer.matching.disable_cycle_dependency_check_in_thread()
+                Return thread_static_implementation_of(Of builder).resolve().build(input, o)
+            End Using
         End Using
     End Function
 

--- a/service/tests/argument/argument.vbproj
+++ b/service/tests/argument/argument.vbproj
@@ -70,6 +70,7 @@
       <DependentUpon>Settings.settings</DependentUpon>
       <DesignTimeSharedInput>True</DesignTimeSharedInput>
     </Compile>
+    <Compile Include="thread_static_argument_default_test.vb" />
     <Compile Include="var_compare_test.vb" />
     <Compile Include="var_test.vb" />
   </ItemGroup>

--- a/service/tests/argument/thread_static_argument_default_test.vb
+++ b/service/tests/argument/thread_static_argument_default_test.vb
@@ -1,0 +1,28 @@
+﻿
+Option Explicit On
+Option Infer Off
+Option Strict On
+
+Imports osi.root.connector
+Imports osi.root.delegates
+Imports osi.root.utt
+Imports osi.root.utt.attributes
+
+<test>
+Public NotInheritable Class thread_static_argument_default_test
+    Private Shared arg As argument(Of Boolean)
+
+    <test>
+    Private Shared Sub run()
+        If Not expectation.is_false(-arg) Then
+            Return
+        End If
+        assertion.is_false(arg Or thread_static_argument_default(Of thread_static_argument_default_test).of(False))
+        Using thread_static_argument_default(Of Boolean, thread_static_argument_default_test).scoped_register(True)
+            assertion.is_true(arg Or thread_static_argument_default(Of thread_static_argument_default_test).of(False))
+        End Using
+    End Sub
+
+    Private Sub New()
+    End Sub
+End Class

--- a/service/tests/argument/thread_static_argument_default_test.vb
+++ b/service/tests/argument/thread_static_argument_default_test.vb
@@ -3,6 +3,7 @@ Option Explicit On
 Option Infer Off
 Option Strict On
 
+Imports System.Threading
 Imports osi.root.connector
 Imports osi.root.delegates
 Imports osi.root.utt
@@ -11,15 +12,36 @@ Imports osi.root.utt.attributes
 <test>
 Public NotInheritable Class thread_static_argument_default_test
     Private Shared arg As argument(Of Boolean)
+    Private Shared arg2 As argument(Of Int32)
 
     <test>
-    Private Shared Sub run()
+    Private Shared Sub current_thread()
         If Not expectation.is_false(-arg) Then
             Return
         End If
         assertion.is_false(arg Or thread_static_argument_default(Of thread_static_argument_default_test).of(False))
         Using thread_static_argument_default(Of Boolean, thread_static_argument_default_test).scoped_register(True)
             assertion.is_true(arg Or thread_static_argument_default(Of thread_static_argument_default_test).of(False))
+        End Using
+    End Sub
+
+    <test>
+    Private Shared Sub multiple_threads()
+        If Not expectation.is_false(-arg2) Then
+            Return
+        End If
+        Dim m As New AutoResetEvent(False)
+        Using thread_static_argument_default(Of Int32, thread_static_argument_default_test).scoped_register(1)
+            assertion.equal(arg2 Or thread_static_argument_default(Of thread_static_argument_default_test).of(2), 1)
+            Dim t As New Thread(
+                Sub()
+                    assertion.equal(arg2 Or
+                                    thread_static_argument_default(Of thread_static_argument_default_test).of(2),
+                                    2)
+                    assertion.is_true(m.force_set())
+                End Sub)
+            t.Start()
+            assertion.is_true(m.wait())
         End Using
     End Sub
 


### PR DESCRIPTION
- thread_static_argument_default allows callers to set the default argument value in current thread.
- disable_cycle_dependency_check uses thread_static_argument_default and compiler/code_gen_rule_wrapper always disables the check to improve performance.