### PR TITLE
Avoid typed node in template body reparser

### DIFF
--- a/service/compiler/b2style/scope.template.vb
+++ b/service/compiler/b2style/scope.template.vb
@@ -114,8 +114,7 @@ Partial Public NotInheritable Class b2style
                 Return s.t.define(type_param_list, n)
             End Function
 
-            Public Function resolve(ByVal n As typed_node,
-                                    ByRef extended_type_name As String) As Boolean
+            Public Function resolve(ByVal n As typed_node, ByRef extended_type_name As String) As Boolean
                 assert(Not n Is Nothing)
                 assert(n.child_count() = 4)
                 Dim paramtypelist As vector(Of String) = code_gens().of_all_children(n.child(2)).dump()

--- a/service/compiler/b2style/template_template.vb
+++ b/service/compiler/b2style/template_template.vb
@@ -84,7 +84,10 @@ Partial Public NotInheritable Class b2style
 
         Public Shared Function template_name(ByVal n As typed_node, ByVal type_count As UInt32) As String
             assert(Not n Is Nothing)
-            Return strcat(n.input_without_ignored(), "__", type_count)
+            assert(type_count > 0)
+            Dim name As String = n.input_without_ignored()
+            assert(Not name.null_or_whitespace())
+            Return String.Concat(name, "__", type_count)
         End Function
 
         ' @VisibleForTesting

--- a/service/compiler/b2style/template_template.vb
+++ b/service/compiler/b2style/template_template.vb
@@ -136,16 +136,16 @@ Partial Public NotInheritable Class b2style
             Return _extended_type_name.str()
         End Function
 
-        Public Function apply(ByVal paramtypelist As vector(Of String), ByRef impl As String) As Boolean
-            assert(Not paramtypelist.null_or_empty())
-            assert(paramtypelist.size() = Me.type_refs.size())
-            _extended_type_name.apply(paramtypelist)
-            For i As UInt32 = 0 To paramtypelist.size() - uint32_1
+        Public Function apply(ByVal types As vector(Of String), ByRef impl As String) As Boolean
+            assert(Not types.null_or_empty())
+            assert(types.size() = Me.type_refs.size())
+            _extended_type_name.apply(types)
+            For i As UInt32 = 0 To types.size() - uint32_1
                 assert(Not Me.type_refs(i))
-                Me.type_refs(i).set(paramtypelist(i))
+                Me.type_refs(i).set(types(i))
             Next
             impl = w.dump()
-            For i As UInt32 = 0 To paramtypelist.size() - uint32_1
+            For i As UInt32 = 0 To types.size() - uint32_1
                 Me.type_refs(i).set(Nothing)
             Next
             Return True

--- a/service/compiler/code_gen/reparser.vb
+++ b/service/compiler/code_gen/reparser.vb
@@ -9,6 +9,7 @@ Imports osi.root.template
 Imports osi.service.automata
 
 Partial Public NotInheritable Class code_gens(Of WRITER As New)
+    ' Do not add extra functionalities into this class, uses out of the current function set should use parser directly.
     Public MustInherit Class reparser
         Implements code_gen(Of WRITER)
 
@@ -30,21 +31,14 @@ Partial Public NotInheritable Class code_gens(Of WRITER As New)
                 raise_error(error_type.user, "Failed to dump ", n)
                 Return False
             End If
-            Using wrapper(n)
-                If Not parser(s, o) Then
-                    raise_error(error_type.user, "Failed to parse ", n)
-                    Return False
-                End If
-                Return True
-            End Using
+            If Not parser(s, o) Then
+                raise_error(error_type.user, "Failed to parse ", n)
+                Return False
+            End If
+            Return True
         End Function
 
         Protected MustOverride Function dump(ByVal n As typed_node, ByRef s As String) As Boolean
-
-        Protected Overridable Function wrapper(ByVal n As typed_node) As IDisposable
-            Return defer.to(Sub()
-                            End Sub)
-        End Function
 
         Protected Overridable Function handle_not_dumpable(ByVal n As typed_node, ByVal o As WRITER) As Boolean
             Return False


### PR DESCRIPTION
This change removed some unnecessary abstractions in the template implementation to make it easier to integrate with class-template-function.